### PR TITLE
feat: improve match accuracy

### DIFF
--- a/DataStucture.cs
+++ b/DataStucture.cs
@@ -1,36 +1,96 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 #pragma warning disable 649 // Suppresses: ___ is never assigned to
 
 // ReSharper disable All
 
 namespace MusicBeePlugin
 {
-    class SearchResult
+    public class SearchResult
     {
         public SearchResultResult result;
         public int code;
     }
 
-    class SearchResultResult
+    public class SearchResultResult
     {
         public int songCount;
         public IEnumerable<SearchResultSong> songs;
     }
 
-    class SearchResultSong
+    public class SearchResultSong : IEquatable<SearchResultSong>
     {
         public string name;
         public long id;
+        public List<SearchResultArtist> artists;
+        public SearchResultAlbum album;
+
+        public bool Equals(SearchResultSong other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return id == other.id;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((SearchResultSong) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return id.GetHashCode();
+        }
+
+        public static bool operator ==(SearchResultSong left, SearchResultSong right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(SearchResultSong left, SearchResultSong right)
+        {
+            return !Equals(left, right);
+        }
+
+        public override string ToString()
+        {
+            return $"Name: {name}, Id: {id}, Artists: {string.Join(",", artists)}, Album: {album}";
+        }
     }
 
-    class LyricResult
+    public class SearchResultArtist
+    {
+        public long id;
+        public string name;
+
+        public override string ToString()
+        {
+            return $"Id: {id}, Name: {name}";
+        }
+    }
+
+    public class SearchResultAlbum
+    {
+        public long id;
+        public string name;
+
+        public override string ToString()
+        {
+            return $"Id: {id}, Name: {name}";
+        }
+    }
+
+    public class LyricResult
     {
         public LyricInner lrc;
         public LyricInner tlyric;
         public int code;
     }
 
-    class LyricInner
+    public class LyricInner
     {
         public string lyric;
     }

--- a/F23.StringSimilarity/Cosine.cs
+++ b/F23.StringSimilarity/Cosine.cs
@@ -1,0 +1,149 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+using System;
+using System.Collections.Generic;
+using F23.StringSimilarity.Interfaces;
+// ReSharper disable LoopCanBeConvertedToQuery
+
+namespace F23.StringSimilarity
+{
+    public class Cosine : ShingleBased, INormalizedStringSimilarity, INormalizedStringDistance
+    {
+        /// <summary>
+        /// Implements Cosine Similarity between strings.The strings are first
+        /// transformed in vectors of occurrences of k-shingles(sequences of k
+        /// characters). In this n-dimensional space, the similarity between the two
+        /// strings is the cosine of their respective vectors.
+        /// </summary>
+        /// <param name="k"></param>
+        public Cosine(int k) : base(k) { }
+
+        /// <summary>
+        /// Implements Cosine Similarity between strings.The strings are first
+        /// transformed in vectors of occurrences of k-shingles(sequences of k
+        /// characters). In this n-dimensional space, the similarity between the two
+        /// strings is the cosine of their respective vectors.
+        /// 
+        /// Default k is 3.
+        /// </summary>
+        public Cosine() { }
+        
+        /// <summary>
+        /// Compute the cosine similarity between strings.
+        /// </summary>
+        /// <param name="s1">The first string to compare.</param>
+        /// <param name="s2">The second string to compare.</param>
+        /// <returns>The cosine similarity in the range [0, 1]</returns>
+        /// <exception cref="T:System.ArgumentNullException">If s1 or s2 is null.</exception>
+        public double Similarity(string s1, string s2)
+        {
+            if (s1 == null)
+            {
+                throw new ArgumentNullException(nameof(s1));
+            }
+
+            if (s2 == null)
+            {
+                throw new ArgumentNullException(nameof(s2));
+            }
+
+            if (s1.Equals(s2))
+            {
+                return 1;
+            }
+
+            if (s1.Length < k || s2.Length < k)
+            {
+                return 0;
+            }
+
+            var profile1 = GetProfile(s1);
+            var profile2 = GetProfile(s2);
+
+            return DotProduct(profile1, profile2) / (Norm(profile1) * Norm(profile2));
+        }
+
+        /// <summary>
+        /// Compute the norm L2 : sqrt(Sum_i( v_i²)).
+        /// </summary>
+        /// <param name="profile"></param>
+        /// <returns></returns>
+        private static double Norm(IDictionary<string, int> profile)
+        {
+            double agg = 0;
+
+            foreach (var entry in profile)
+            {
+                agg += 1.0 * entry.Value * entry.Value;
+            }
+
+            return Math.Sqrt(agg);
+        }
+
+        private static double DotProduct(IDictionary<string, int> profile1,
+            IDictionary<string, int> profile2)
+        {
+            // Loop over the smallest map
+            var small_profile = profile2;
+            var large_profile = profile1;
+
+            if (profile1.Count < profile2.Count)
+            {
+                small_profile = profile1;
+                large_profile = profile2;
+            }
+
+            double agg = 0;
+            foreach (var entry in small_profile)
+            {
+                if (!large_profile.TryGetValue(entry.Key, out var i)) continue;
+
+                agg += 1.0 * entry.Value * i;
+            }
+
+            return agg;
+        }
+
+        /// <summary>
+        /// Returns 1.0 - similarity.
+        /// </summary>
+        /// <param name="s1">The first string to compare.</param>
+        /// <param name="s2">The second string to compare.</param>
+        /// <returns>1.0 - the cosine similarity in the range [0, 1]</returns>
+        /// <exception cref="ArgumentNullException">If s1 or s2 is null.</exception>
+        public double Distance(string s1, string s2)
+            => 1.0 - Similarity(s1, s2);
+        
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="profile1"></param>
+        /// <param name="profile2"></param>
+        /// <returns></returns>
+        public double Similarity(IDictionary<string, int> profile1, IDictionary<string, int> profile2)
+            => DotProduct(profile1, profile2)
+            / (Norm(profile1) * Norm(profile2));
+    }
+}

--- a/F23.StringSimilarity/Damerau.cs
+++ b/F23.StringSimilarity/Damerau.cs
@@ -1,0 +1,141 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+using System;
+using System.Collections.Generic;
+using F23.StringSimilarity.Interfaces;
+// ReSharper disable ForCanBeConvertedToForeach
+// ReSharper disable SuggestVarOrType_Elsewhere
+
+namespace F23.StringSimilarity
+{
+    /// <summary>
+    /// Implementation of Damerau-Levenshtein distance with transposition (also 
+    /// sometimes calls unrestricted Damerau-Levenshtein distance).
+    /// It is the minimum number of operations needed to transform one string into
+    /// the other, where an operation is defined as an insertion, deletion, or
+    /// substitution of a single character, or a transposition of two adjacent
+    /// characters.
+    /// It does respect triangle inequality, and is thus a metric distance.
+    /// This is not to be confused with the optimal string alignment distance, which
+    /// is an extension where no substring can be edited more than once.
+    /// </summary>
+    public class Damerau : IMetricStringDistance
+    {
+        /// <summary>
+        /// Compute the distance between strings: the minimum number of operations
+        /// needed to transform one string into the other(insertion, deletion,
+        /// substitution of a single character, or a transposition of two adjacent
+        /// characters).
+        /// </summary>
+        /// <param name="s1">The first string to compare.</param>
+        /// <param name="s2">The second string to compare.</param>
+        /// <returns>The computed distance.</returns>
+        /// <exception cref="ArgumentNullException">If s1 or s2 is null.</exception>
+        public double Distance(string s1, string s2)
+        {
+            if (s1 == null)
+            {
+                throw new ArgumentNullException(nameof(s1));
+            }
+
+            if (s2 == null)
+            {
+                throw new ArgumentNullException(nameof(s2));
+            }
+
+            if (s1.Equals(s2))
+            {
+                return 0;
+            }
+
+            // Infinite distance is the max possible distance
+            int inf = s1.Length + s2.Length;
+
+            // Create and initialize the character array indices
+            var da = new Dictionary<char, int>();
+
+            for (int d = 0; d < s1.Length; d++)
+            {
+                da[s1[d]] = 0;
+            }
+
+            for (int d = 0; d < s2.Length; d++)
+            {
+                da[s2[d]] = 0;
+            }
+
+            // Create the distance matrix H[0 .. s1.length+1][0 .. s2.length+1]
+            int[,] h = new int[s1.Length + 2, s2.Length + 2];
+
+            // Initialize the left and top edges of H
+            for (int i = 0; i <= s1.Length; i++)
+            {
+                h[i + 1, 0] = inf;
+                h[i + 1, 1] = i;
+            }
+
+            for (int j = 0; j <= s2.Length; j++)
+            {
+                h[0, j + 1] = inf;
+                h[1, j + 1] = j;
+            }
+
+            // Fill in the distance matrix H
+            // Look at each character in s1
+            for (int i = 1; i <= s1.Length; i++)
+            {
+                int db = 0;
+
+                // Look at each character in b
+                for (int j = 1; j <= s2.Length; j++)
+                {
+                    int i1 = da[s2[j - 1]];
+                    int j1 = db;
+
+                    int cost = 1;
+                    if (s1[i - 1] == s2[j - 1])
+                    {
+                        cost = 0;
+                        db = j;
+                    }
+
+                    h[i + 1, j + 1] = Min(
+                        h[i, j] + cost,  // Substitution
+                        h[i + 1, j] + 1, // Insertion
+                        h[i, j + 1] + 1, // Deletion
+                        h[i1, j1] + (i - i1 - 1) + 1 + (j - j1 - 1)
+                    );
+                }
+
+                da[s1[i - 1]] = i;
+            }
+
+            return h[s1.Length + 1, s2.Length + 1];
+        }
+
+        private static int Min(int a, int b, int c, int d)
+             => Math.Min(a, Math.Min(b, Math.Min(c, d)));
+    }
+}

--- a/F23.StringSimilarity/Experimental/Sift4.cs
+++ b/F23.StringSimilarity/Experimental/Sift4.cs
@@ -1,0 +1,207 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+using System;
+using System.Collections.Generic;
+using F23.StringSimilarity.Interfaces;
+
+namespace F23.StringSimilarity.Experimental
+{
+    /// <summary>
+    /// Sift4 - a general purpose string distance algorithm inspired by JaroWinkler
+    /// and Longest Common Subsequence.
+    /// Original JavaScript algorithm by siderite, java port by Nathan Fischer 2016.
+    /// https://siderite.blogspot.com/2014/11/super-fast-and-accurate-string-distance.html
+    /// </summary>
+    public class Sift4 : IStringDistance
+    {
+        private const int DEFAULT_MAX_OFFSET = 10;
+
+        /// <summary>
+        /// Gets or sets the maximum distance to search for character transposition.
+        /// Compuse cost of algorithm is O(n . MaxOffset)
+        /// </summary>
+        public int MaxOffset { get; set; } = DEFAULT_MAX_OFFSET;
+
+        /// <summary>
+        /// Used to store relation between same character in different positions
+        /// c1 and c2 in the input strings.
+        /// </summary>
+        /// <remarks>
+        /// .NET port notes: should this be a struct instead?
+        /// </remarks>
+        private class Offset
+        {
+            internal readonly int c1;
+            internal readonly int c2;
+            internal bool trans;
+
+            internal Offset(int c1, int c2, bool trans)
+            {
+                this.c1 = c1;
+                this.c2 = c2;
+                this.trans = trans;
+            }
+        }
+
+        /// <summary>
+        /// Sift4 - a general purpose string distance algorithm inspired by JaroWinkler
+        /// and Longest Common Subsequence.
+        /// Original JavaScript algorithm by siderite, java port by Nathan Fischer 2016.
+        /// https://siderite.blogspot.com/2014/11/super-fast-and-accurate-string-distance.html
+        /// </summary>
+        /// <param name="s1"></param>
+        /// <param name="s2"></param>
+        /// <returns></returns>
+        public double Distance(string s1, string s2)
+        {
+            if (string.IsNullOrEmpty(s1))
+            {
+                if (s2 == null)
+                {
+                    return 0;
+                }
+
+                return s2.Length;
+            }
+
+            if (string.IsNullOrEmpty(s2))
+            {
+                return s1.Length;
+            }
+
+            int l1 = s1.Length;
+            int l2 = s2.Length;
+
+            int c1 = 0;  //cursor for string 1
+            int c2 = 0;  //cursor for string 2
+            int lcss = 0;  //largest common subsequence
+            int local_cs = 0; //local common substring
+            int trans = 0;  //number of transpositions ('ab' vs 'ba')
+
+            // offset pair array, for computing the transpositions
+            var offset_arr = new List<Offset>();
+
+            while ((c1 < l1) && (c2 < l2))
+            {
+                if (s1[c1] == s2[c2])
+                {
+                    local_cs++;
+                    bool is_trans = false;
+                    // see if current match is a transposition
+                    int i = 0;
+                    while (i < offset_arr.Count)
+                    {
+                        Offset ofs = offset_arr[i];
+                        if (c1 <= ofs.c1 || c2 <= ofs.c2)
+                        {
+                            // when two matches cross, the one considered a
+                            // transposition is the one with the largest difference
+                            // in offsets
+                            is_trans = Math.Abs(c2 - c1) >= Math.Abs(ofs.c2 - ofs.c1);
+
+                            if (is_trans)
+                            {
+                                trans++;
+                            }
+                            else
+                            {
+                                if (!ofs.trans)
+                                {
+                                    ofs.trans = true;
+                                    trans++;
+                                }
+                            }
+
+                            break;
+                        }
+                        else
+                        {
+                            if (c1 > ofs.c2 && c2 > ofs.c1)
+                            {
+                                offset_arr.RemoveAt(i);
+                            }
+                            else
+                            {
+                                i++;
+                            }
+                        }
+                    }
+
+                    offset_arr.Add(new Offset(c1, c2, is_trans));
+                }
+                else
+                {
+                    // s1.charAt(c1) != s2.charAt(c2)
+                    lcss += local_cs;
+                    local_cs = 0;
+                    if (c1 != c2)
+                    {
+                        //using min allows the computation of transpositions
+                        c1 = Math.Min(c1, c2);
+                        c2 = c1;
+                    }
+
+                    // if matching characters are found, remove 1 from both cursors
+                    // (they get incremented at the end of the loop)
+                    // so that we can have only one code block handling matches
+                    for (int i = 0;
+                         i < MaxOffset && (c1 + i < l1 || c2 + i < l2);
+                         i++)
+                    {
+                        if ((c1 + i < l1) && (s1[c1 + i] == s2[c2]))
+                        {
+                            c1 += i - 1;
+                            c2--;
+                            break;
+                        }
+
+                        if ((c2 + i < l2) && (s1[c1] == s2[c2 + i]))
+                        {
+                            c1--;
+                            c2 += i - 1;
+                            break;
+                        }
+                    }
+                }
+                c1++;
+                c2++;
+                // this covers the case where the last match is on the last token
+                // in list, so that it can compute transpositions correctly
+                if ((c1 >= l1) || (c2 >= l2))
+                {
+                    lcss += local_cs;
+                    local_cs = 0;
+                    c1 = Math.Min(c1, c2);
+                    c2 = c1;
+                }
+            }
+
+            lcss += local_cs;
+
+            // add the cost of transpositions to the final result
+            return Math.Round((double) (Math.Max(l1, l2) - lcss + trans));
+        }
+    }
+}

--- a/F23.StringSimilarity/ICharacterSubstitution.cs
+++ b/F23.StringSimilarity/ICharacterSubstitution.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace F23.StringSimilarity
+{
+    /// Used to indicate the cost of character substitution.
+    ///
+    /// Cost should always be in [0.0 .. 1.0]
+    /// For example, in an OCR application, cost('o', 'a') could be 0.4
+    /// In a checkspelling application, cost('u', 'i') could be 0.4 because these are
+    /// next to each other on the keyboard...
+    /// In search engine keyword usage the . is mostly ignored, so deletion of a . within a string is not that costly. eg a search in Google on K.E.Y.B.O.O.S.T will return Keyboost.
+    /// In search engine keyword usage the space is often forgotten, so insertion of space within a string is not that costly. eg a search in Google on seopageoptimizer will return SEO Page Optimizer
+
+    public interface ICharacterSubstitution
+    {
+        /// <summary>
+        /// Indicate the cost of substitution c1 and c2.
+        /// </summary>
+        /// <param name="c1">The first character of the substitution.</param>
+        /// <param name="c2">The second character of the substitution.</param>
+        /// <returns>The cost in the range [0, 1].</returns>
+        double Cost(char c1, char c2);
+
+
+        /// <summary>
+        /// Indicate the cost of deleting c1.
+        /// </summary>
+        /// <param name="c1">The character to be deleted.</param>
+        /// <returns>The cost in the range [0, 1].</returns>
+        double DeletionCost(char c1);
+
+        /// <summary>
+        /// Indicate the cost of inserting c1.
+        /// </summary>
+        /// <param name="c1">The character to be inserted.</param>
+        /// <returns>The cost in the range [0, 1].</returns>
+        double InsertionCost(char c1);
+    }
+}

--- a/F23.StringSimilarity/Interfaces/IMetricStringDistance.cs
+++ b/F23.StringSimilarity/Interfaces/IMetricStringDistance.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace F23.StringSimilarity.Interfaces
+{
+    /// <summary>
+    /// String distances that implement this interface are metrics, which means:
+    ///  - d(x, y) ≥ 0     (non-negativity, or separation axiom)
+    ///  - d(x, y) = 0   if and only if   x = y     (identity, or coincidence axiom)
+    ///  - d(x, y) = d(y, x)     (symmetry)
+    ///  - d(x, z) ≤ d(x, y) + d(y, z)     (triangle inequality).
+    /// </summary>
+    public interface IMetricStringDistance : IStringDistance
+    {
+        /// <summary>
+        /// Compute and return the metric distance.
+        /// </summary>
+        /// <param name="s1"></param>
+        /// <param name="s2"></param>
+        /// <returns></returns>
+        new double Distance(string s1, string s2);
+    }
+}

--- a/F23.StringSimilarity/Interfaces/INormalizedStringDistance.cs
+++ b/F23.StringSimilarity/Interfaces/INormalizedStringDistance.cs
@@ -1,0 +1,30 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace F23.StringSimilarity.Interfaces
+{
+    public interface INormalizedStringDistance : IStringDistance
+    {
+    }
+}

--- a/F23.StringSimilarity/Interfaces/INormalizedStringSimilarity.cs
+++ b/F23.StringSimilarity/Interfaces/INormalizedStringSimilarity.cs
@@ -1,0 +1,30 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace F23.StringSimilarity.Interfaces
+{
+    public interface INormalizedStringSimilarity : IStringSimilarity
+    {
+    }
+}

--- a/F23.StringSimilarity/Interfaces/IStringDistance.cs
+++ b/F23.StringSimilarity/Interfaces/IStringDistance.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace F23.StringSimilarity.Interfaces
+{
+    public interface IStringDistance
+    {
+        /// <summary>
+        /// Compute and return a measure of distance.
+        /// Must be >= 0.
+        /// </summary>
+        /// <param name="s1"></param>
+        /// <param name="s2"></param>
+        /// <returns></returns>
+        double Distance(string s1, string s2);
+    }
+}

--- a/F23.StringSimilarity/Interfaces/IStringSimilarity.cs
+++ b/F23.StringSimilarity/Interfaces/IStringSimilarity.cs
@@ -1,0 +1,37 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace F23.StringSimilarity.Interfaces
+{
+    public interface IStringSimilarity
+    {
+        /// <summary>
+        /// Compute and return a measure of similarity between 2 strings.
+        /// </summary>
+        /// <param name="s1">The first string</param>
+        /// <param name="s2">The second string</param>
+        /// <returns>Similarity (0 means both strings are completely different)</returns>
+        double Similarity(string s1, string s2);
+    }
+}

--- a/F23.StringSimilarity/Jaccard.cs
+++ b/F23.StringSimilarity/Jaccard.cs
@@ -1,0 +1,107 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+using System;
+using System.Collections.Generic;
+using F23.StringSimilarity.Interfaces;
+
+// ReSharper disable LoopCanBeConvertedToQuery
+
+namespace F23.StringSimilarity
+{
+    /// <summary>
+    /// Each input string is converted into a set of n-grams, the Jaccard index is
+    /// then computed as |V1 inter V2| / |V1 union V2|.
+    /// Like Q-Gram distance, the input strings are first converted into sets of
+    /// n-grams (sequences of n characters, also called k-shingles), but this time
+    /// the cardinality of each n-gram is not taken into account.
+    /// Distance is computed as 1 - cosine similarity.
+    /// Jaccard index is a metric distance.
+    /// </summary>
+    public class Jaccard : ShingleBased, IMetricStringDistance, INormalizedStringDistance, INormalizedStringSimilarity
+    {
+        /// <summary>
+        /// The strings are first transformed into sets of k-shingles (sequences of k
+        /// characters), then Jaccard index is computed as |A inter B| / |A union B|.
+        /// The default value of k is 3.
+        /// </summary>
+        /// <param name="k"></param>
+        public Jaccard(int k) : base(k) { }
+
+        /// <summary>
+        /// The strings are first transformed into sets of k-shingles (sequences of k
+        /// characters), then Jaccard index is computed as |A inter B| / |A union B|.
+        /// The default value of k is 3.
+        /// </summary>
+        public Jaccard() { }
+
+        /// <summary>
+        /// Compute jaccard index: |A inter B| / |A union B|.
+        /// </summary>
+        /// <param name="s1">The first string to compare.</param>
+        /// <param name="s2">The second string to compare.</param>
+        /// <returns>The Jaccard index in the range [0, 1]</returns>
+        /// <exception cref="ArgumentNullException">If s1 or s2 is null.</exception>
+        public double Similarity(string s1, string s2)
+        {
+            if (s1 == null)
+            {
+                throw new ArgumentNullException(nameof(s1));
+            }
+
+            if (s2 == null)
+            {
+                throw new ArgumentNullException(nameof(s2));
+            }
+
+            if (s1.Equals(s2))
+            {
+                return 1;
+            }
+
+            var profile1 = GetProfile(s1);
+            var profile2 = GetProfile(s2);
+
+            var union = new HashSet<string>();
+            union.UnionWith(profile1.Keys);
+            union.UnionWith(profile2.Keys);
+
+            int inter = profile1.Keys.Count + profile2.Keys.Count
+                        - union.Count;
+
+            return 1.0 * inter / union.Count;
+        }
+
+
+        /// <summary>
+        /// Distance is computed as 1 - similarity.
+        /// </summary>
+        /// <param name="s1">The first string to compare.</param>
+        /// <param name="s2">The second string to compare.</param>
+        /// <returns>1 - the Jaccard similarity.</returns>
+        /// <exception cref="ArgumentNullException">If s1 or s2 is null.</exception>
+        public double Distance(string s1, string s2)
+            => 1.0 - Similarity(s1, s2);
+    }
+}

--- a/F23.StringSimilarity/JaroWinkler.cs
+++ b/F23.StringSimilarity/JaroWinkler.cs
@@ -1,0 +1,198 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+using System;
+using System.Linq;
+using F23.StringSimilarity.Interfaces;
+// ReSharper disable SuggestVarOrType_Elsewhere
+// ReSharper disable LoopCanBeConvertedToQuery
+
+namespace F23.StringSimilarity
+{
+    /// The Jaro–Winkler distance metric is designed and best suited for short
+    /// strings such as person names, and to detect typos; it is (roughly) a
+    /// variation of Damerau-Levenshtein, where the substitution of 2 close
+    /// characters is considered less important then the substitution of 2 characters
+    /// that a far from each other.
+    /// Jaro-Winkler was developed in the area of record linkage (duplicate
+    /// detection) (Winkler, 1990). It returns a value in the interval [0.0, 1.0].
+    /// The distance is computed as 1 - Jaro-Winkler similarity.
+    public class JaroWinkler : INormalizedStringSimilarity, INormalizedStringDistance
+    {
+        private const double DEFAULT_THRESHOLD = 0.7;
+        private const int THREE = 3;
+        private const double JW_COEF = 0.1;
+
+        /// <summary>
+        /// The current value of the threshold used for adding the Winkler bonus. The default value is 0.7.
+        /// </summary>
+        private double Threshold { get; }
+        
+        /// <summary>
+        /// Creates a new instance with default threshold (0.7)
+        /// </summary>
+        public JaroWinkler()
+        {
+            Threshold = DEFAULT_THRESHOLD;
+        }
+        
+        /// <summary>
+        /// Creates a new instance with given threshold to determine when Winkler bonus should
+        /// be used. Set threshold to a negative value to get the Jaro distance.
+        /// </summary>
+        /// <param name="threshold"></param>
+        public JaroWinkler(double threshold)
+        {
+            Threshold = threshold;
+        }
+
+        /// <summary>
+        /// Compute Jaro-Winkler similarity.
+        /// </summary>
+        /// <param name="s1">The first string to compare.</param>
+        /// <param name="s2">The second string to compare.</param>
+        /// <returns>The Jaro-Winkler similarity in the range [0, 1]</returns>
+        /// <exception cref="ArgumentNullException">If s1 or s2 is null.</exception>
+        public double Similarity(string s1, string s2)
+        {
+            if (s1 == null)
+            {
+                throw new ArgumentNullException(nameof(s1));    
+            }
+
+            if (s2 == null)
+            {
+                throw new ArgumentNullException(nameof(s2));
+            }
+
+            if (s1.Equals(s2))
+            {
+                return 1f;
+            }
+
+            int[] mtp = Matches(s1, s2);
+            float m = mtp[0];
+            if (m == 0)
+            {
+                return 0f;
+            }
+            double j = ((m / s1.Length + m / s2.Length + (m - mtp[1]) / m))
+                    / THREE;
+            double jw = j;
+
+            if (j > Threshold)
+            {
+                jw = j + Math.Min(JW_COEF, 1.0 / mtp[THREE]) * mtp[2] * (1 - j);
+            }
+            return jw;
+        }
+
+        /// <summary>
+        /// Return 1 - similarity.
+        /// </summary>
+        /// <param name="s1">The first string to compare.</param>
+        /// <param name="s2">The second string to compare.</param>
+        /// <returns>1 - similarity</returns>
+        /// <exception cref="ArgumentNullException">If s1 or s2 is null.</exception>
+        public double Distance(string s1, string s2)
+            => 1.0 - Similarity(s1, s2);
+
+        private static int[] Matches(string s1, string s2)
+        {
+            string max, min;
+            if (s1.Length > s2.Length)
+            {
+                max = s1;
+                min = s2;
+            }
+            else
+            {
+                max = s2;
+                min = s1;
+            }
+            int range = Math.Max(max.Length / 2 - 1, 0);
+
+            //int[] matchIndexes = new int[min.Length];
+            //Arrays.fill(matchIndexes, -1);
+            int[] match_indexes = Enumerable.Repeat(-1, min.Length).ToArray();
+
+            bool[] match_flags = new bool[max.Length];
+            int matches = 0;
+            for (int mi = 0; mi < min.Length; mi++)
+            {
+                char c1 = min[mi];
+                for (int xi = Math.Max(mi - range, 0),
+                        xn = Math.Min(mi + range + 1, max.Length); xi < xn; xi++)
+                {
+                    if (!match_flags[xi] && c1 == max[xi])
+                    {
+                        match_indexes[mi] = xi;
+                        match_flags[xi] = true;
+                        matches++;
+                        break;
+                    }
+                }
+            }
+            char[] ms1 = new char[matches];
+            char[] ms2 = new char[matches];
+            for (int i = 0, si = 0; i < min.Length; i++)
+            {
+                if (match_indexes[i] != -1)
+                {
+                    ms1[si] = min[i];
+                    si++;
+                }
+            }
+            for (int i = 0, si = 0; i < max.Length; i++)
+            {
+                if (match_flags[i])
+                {
+                    ms2[si] = max[i];
+                    si++;
+                }
+            }
+            int transpositions = 0;
+            for (int mi = 0; mi < ms1.Length; mi++)
+            {
+                if (ms1[mi] != ms2[mi])
+                {
+                    transpositions++;
+                }
+            }
+            int prefix = 0;
+            for (int mi = 0; mi < min.Length; mi++)
+            {
+                if (s1[mi] == s2[mi])
+                {
+                    prefix++;
+                }
+                else
+                {
+                    break;
+                }
+            }
+            return new[] { matches, transpositions / 2, prefix, max.Length };
+        }
+    }
+}

--- a/F23.StringSimilarity/Levenshtein.cs
+++ b/F23.StringSimilarity/Levenshtein.cs
@@ -1,0 +1,135 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+using System;
+using F23.StringSimilarity.Interfaces;
+// ReSharper disable SuggestVarOrType_Elsewhere
+// ReSharper disable TooWideLocalVariableScope
+
+namespace F23.StringSimilarity
+{
+    /// The Levenshtein distance between two words is the Minimum number of
+    /// single-character edits (insertions, deletions or substitutions) required to
+    /// change one string into the other.
+    public class Levenshtein : IMetricStringDistance
+    {
+        /// <summary>
+        /// The Levenshtein distance, or edit distance, between two words is the
+        /// Minimum number of single-character edits (insertions, deletions or
+        /// substitutions) required to change one word into the other.
+        ///
+        /// http://en.wikipedia.org/wiki/Levenshtein_distance
+        ///
+        /// It is always at least the difference of the sizes of the two strings.
+        /// It is at most the length of the longer string.
+        /// It is zero if and only if the strings are equal.
+        /// If the strings are the same size, the HamMing distance is an upper bound
+        /// on the Levenshtein distance.
+        /// The Levenshtein distance verifies the triangle inequality (the distance
+        /// between two strings is no greater than the sum Levenshtein distances from
+        /// a third string).
+        ///
+        /// Implementation uses dynamic programMing (Wagner–Fischer algorithm), with
+        /// only 2 rows of data. The space requirement is thus O(m) and the algorithm
+        /// runs in O(mn).
+        /// </summary>
+        /// <param name="s1">The first string to compare.</param>
+        /// <param name="s2">The second string to compare.</param>
+        /// <returns>The Levenshtein distance between strings</returns>
+        /// <exception cref="ArgumentNullException">If s1 or s2 is null.</exception>
+        public double Distance(string s1, string s2)
+        {
+            if (s1 == null)
+            {
+                throw new ArgumentNullException(nameof(s1));
+            }
+
+            if (s2 == null)
+            {
+                throw new ArgumentNullException(nameof(s2));
+            }
+
+            if (s1.Equals(s2))
+            {
+                return 0;
+            }
+
+            if (s1.Length == 0)
+            {
+                return s2.Length;
+            }
+
+            if (s2.Length == 0)
+            {
+                return s1.Length;
+            }
+
+            // create two work vectors of integer distances
+            int[] v0 = new int[s2.Length + 1];
+            int[] v1 = new int[s2.Length + 1];
+            int[] vtemp;
+
+            // initialize v0 (the previous row of distances)
+            // this row is A[0][i]: edit distance for an empty s
+            // the distance is just the number of characters to delete from t
+            for (int i = 0; i < v0.Length; i++)
+            {
+                v0[i] = i;
+            }
+
+            for (int i = 0; i < s1.Length; i++)
+            {
+                // calculate v1 (current row distances) from the previous row v0
+                // first element of v1 is A[i+1][0]
+                //   edit distance is delete (i+1) chars from s to match empty t
+                v1[0] = i + 1;
+
+                // use formula to fill in the rest of the row
+                for (int j = 0; j < s2.Length; j++)
+                {
+                    int cost = 1;
+                    if (s1[i] == s2[j])
+                    {
+                        cost = 0;
+                    }
+                    v1[j + 1] = Math.Min(
+                            v1[j] + 1,              // Cost of insertion
+                            Math.Min(
+                                    v0[j + 1] + 1,  // Cost of remove
+                                    v0[j] + cost)); // Cost of substitution
+                }
+
+                // copy v1 (current row) to v0 (previous row) for next iteration
+                //System.arraycopy(v1, 0, v0, 0, v0.length);
+
+                // Flip references to current and previous row
+                vtemp = v0;
+                v0 = v1;
+                v1 = vtemp;
+            }
+
+            return v0[s2.Length];
+        }
+    }
+}

--- a/F23.StringSimilarity/LongestCommonSubsequence.cs
+++ b/F23.StringSimilarity/LongestCommonSubsequence.cs
@@ -1,0 +1,150 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+using System;
+using F23.StringSimilarity.Interfaces;
+// ReSharper disable SuggestVarOrType_Elsewhere
+
+namespace F23.StringSimilarity
+{
+    /// The longest common subsequence (LCS) problem consists in finding the longest
+    /// subsequence common to two (or more) sequences. It differs from problems of
+    /// finding common substrings: unlike substrings, subsequences are not required
+    /// to occupy consecutive positions within the original sequences.
+    ///
+    /// It is used by the diff utility, by Git for reconciling multiple changes, etc.
+    ///
+    /// The LCS distance between Strings X (length n) and Y (length m) is n + m - 2
+    /// |LCS(X, Y)| min = 0 max = n + m
+    ///
+    /// LCS distance is equivalent to Levenshtein distance, when only insertion and
+    /// deletion is allowed (no substitution), or when the cost of the substitution
+    /// is the double of the cost of an insertion or deletion.
+    ///
+    /// ! This class currently implements the dynamic programming approach, which has
+    /// a space requirement O(m * n)!
+    public class LongestCommonSubsequence : IStringDistance
+    {
+        /// <summary>
+        /// Return the LCS distance between strings s1 and s2, computed as |s1| +
+        /// |s2| - 2 * |LCS(s1, s2)|.
+        /// </summary>
+        /// <param name="s1">The first string to compare.</param>
+        /// <param name="s2">The second string to compare.</param>
+        /// <returns>
+        /// The LCS distance between strings s1 and s2, computed as |s1| +
+        /// |s2| - 2 * |LCS(s1, s2)|
+        /// </returns>
+        /// <exception cref="ArgumentNullException">If s1 or s2 is null.</exception>
+        public double Distance(string s1, string s2)
+        {
+            if (s1 == null)
+            {
+                throw new ArgumentNullException(nameof(s1));
+            }
+
+            if (s2 == null)
+            {
+                throw new ArgumentNullException(nameof(s2));
+            }
+
+            if (s1.Equals(s2))
+            {
+                return 0;
+            }
+
+            return s1.Length + s2.Length - 2 * Length(s1, s2);
+        }
+
+        /// <summary>
+        ///  Return the length of Longest Common Subsequence (LCS) between strings s1
+        ///  and s2.
+        /// </summary>
+        /// <param name="s1">The first string to compare.</param>
+        /// <param name="s2">The second string to compare.</param>
+        /// <returns>The length of LCS(s2, s2)</returns>
+        /// <exception cref="ArgumentNullException">If s1 or s2 is null.</exception>
+        public int Length(string s1, string s2)
+        {
+            if (s1 == null)
+            {
+                throw new ArgumentNullException(nameof(s1));
+            }
+
+            if (s2 == null)
+            {
+                throw new ArgumentNullException(nameof(s2));
+            }
+
+            /* function LCSLength(X[1..m], Y[1..n])
+             C = array(0..m, 0..n)
+             for i := 0..m
+             C[i,0] = 0
+             for j := 0..n
+             C[0,j] = 0
+             for i := 1..m
+             for j := 1..n
+             if X[i] = Y[j]
+             C[i,j] := C[i-1,j-1] + 1
+             else
+             C[i,j] := max(C[i,j-1], C[i-1,j])
+             return C[m,n]
+             */
+            int s1_length = s1.Length;
+            int s2_length = s2.Length;
+            char[] x = s1.ToCharArray();
+            char[] y = s2.ToCharArray();
+
+            int[,] c = new int[s1_length + 1, s2_length + 1];
+
+            for (int i = 0; i <= s1_length; i++)
+            {
+                c[i, 0] = 0;
+            }
+
+            for (int j = 0; j <= s2_length; j++)
+            {
+                c[0, j] = 0;
+            }
+
+            for (int i = 1; i <= s1_length; i++)
+            {
+                for (int j = 1; j <= s2_length; j++)
+                {
+                    if (x[i - 1] == y[j - 1])
+                    {
+                        c[i, j] = c[i - 1, j - 1] + 1;
+
+                    }
+                    else
+                    {
+                        c[i, j] = Math.Max(c[i, j - 1], c[i - 1, j]);
+                    }
+                }
+            }
+
+            return c[s1_length, s2_length];
+        }
+    }
+}

--- a/F23.StringSimilarity/MetricLCS.cs
+++ b/F23.StringSimilarity/MetricLCS.cs
@@ -1,0 +1,72 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+using System;
+using F23.StringSimilarity.Interfaces;
+
+namespace F23.StringSimilarity
+{
+    /// <summary>
+    /// Distance metric based on Longest Common Subsequence, from the notes "An
+    /// LCS-based string metric" by Daniel Bakkelund.
+    /// </summary>
+    public class MetricLCS : IMetricStringDistance, INormalizedStringDistance
+    {
+        private readonly LongestCommonSubsequence lcs = new LongestCommonSubsequence();
+
+        /// <summary>
+        /// Distance metric based on Longest Common Subsequence, computed as
+        /// 1 - |LCS(s1, s2)| / max(|s1|, |s2|).
+        /// </summary>
+        /// <param name="s1">The first string to compare.</param>
+        /// <param name="s2">The second string to compare.</param>
+        /// <returns>LCS distance metric</returns>
+        /// <exception cref="ArgumentNullException">If s1 or s2 is null.</exception>
+        public double Distance(string s1, string s2)
+        {
+            if (s1 == null)
+            {
+                throw new ArgumentNullException(nameof(s1));
+            }
+
+            if (s2 == null)
+            {
+                throw new ArgumentNullException(nameof(s2));
+            }
+
+            if (s1.Equals(s2))
+            {
+                return 0;
+            }
+
+            int m_len = Math.Max(s1.Length, s2.Length);
+
+            if (m_len == 0) return 0.0;
+
+            return 1.0
+                    - (1.0 * lcs.Length(s1, s2))
+                    / m_len;
+        }
+    }
+}

--- a/F23.StringSimilarity/NGram.cs
+++ b/F23.StringSimilarity/NGram.cs
@@ -1,0 +1,185 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+using System;
+using F23.StringSimilarity.Interfaces;
+// ReSharper disable ConvertIfStatementToReturnStatement
+// ReSharper disable SuggestVarOrType_Elsewhere
+// ReSharper disable JoinDeclarationAndInitializer
+// ReSharper disable TooWideLocalVariableScope
+
+namespace F23.StringSimilarity
+{
+    /// <summary>
+    /// N-Gram Similarity as defined by Kondrak, "N-Gram Similarity and Distance",
+    /// String Processing and Information Retrieval, Lecture Notes in Computer
+    /// Science Volume 3772, 2005, pp 115-126.
+    /// 
+    /// The algorithm uses affixing with special character '\n' to increase the
+    /// weight of first characters. The normalization is achieved by dividing the
+    /// total similarity score the original length of the longest word.
+    /// 
+    /// total similarity score the original length of the longest word.
+    /// </summary>
+    public class NGram : INormalizedStringDistance
+    {
+        private const int DEFAULT_N = 2;
+        private readonly int n;
+
+        public NGram() : this(DEFAULT_N) { }
+
+        public NGram(int n)
+        {
+            this.n = n;
+        }
+
+        /// <summary>
+        /// Compute n-gram distance.
+        /// </summary>
+        /// <param name="s0">The first string to compare.</param>
+        /// <param name="s1">The second string to compare.</param>
+        /// <returns>The computed n-gram distance in the range [0, 1]</returns>
+        /// <exception cref="ArgumentNullException">If s0 or s1 is null.</exception>
+        public double Distance(string s0, string s1)
+        {
+            if (s0 == null)
+            {
+                throw new ArgumentNullException(nameof(s0));
+            }
+
+            if (s1 == null)
+            {
+                throw new ArgumentNullException(nameof(s1));
+            }
+
+            const char special = '\n';
+            int sl = s0.Length;
+            int tl = s1.Length;
+
+            if (s0.Equals(s1))
+            {
+                return 0;
+            }
+
+            if (sl == 0 || tl == 0)
+            {
+                return 1;
+            }
+
+            int cost = 0;
+            if (sl < n || tl < n)
+            {
+                for (int i1 = 0, ni = Math.Min(sl, tl); i1 < ni; i1++)
+                {
+                    if (s0[i1] == s1[i1])
+                    {
+                        cost++;
+                    }
+                }
+                return (float)cost / Math.Max(sl, tl);
+            }
+
+            char[] sa = new char[sl + n - 1];
+            float[] p; // 'previous' cost array, horizontally
+            float[] d; // Cost array, horizontally
+            float[] d2; // Placeholder to assist in swapping p and d
+
+            // Construct sa with prefix
+            for (int i1 = 0; i1 < sa.Length; i1++)
+            {
+                if (i1 < n - 1)
+                {
+                    sa[i1] = special; // Add prefix
+                }
+                else
+                {
+                    sa[i1] = s0[i1 - n + 1];
+                }
+            }
+            p = new float[sl + 1];
+            d = new float[sl + 1];
+
+            // Indexes into strings s and t
+            int i; // Iterates through source
+            int j; // Iterates through target
+
+            char[] t_j = new char[n]; // jth n-gram of t
+
+            for (i = 0; i <= sl; i++)
+            {
+                p[i] = i;
+            }
+
+            for (j = 1; j <= tl; j++)
+            {
+                // Construct t_j n-gram 
+                if (j < n)
+                {
+                    for (int ti = 0; ti < n - j; ti++)
+                    {
+                        t_j[ti] = special; // Add prefix
+                    }
+                    for (int ti = n - j; ti < n; ti++)
+                    {
+                        t_j[ti] = s1[ti - (n - j)];
+                    }
+                }
+                else
+                {
+                    t_j = s1.Substring(j - n, n).ToCharArray();
+                }
+                d[0] = j;
+                for (i = 1; i <= sl; i++)
+                {
+                    cost = 0;
+                    int tn = n;
+                    // Compare sa to t_j
+                    for (int ni = 0; ni < n; ni++)
+                    {
+                        if (sa[i - 1 + ni] != t_j[ni])
+                        {
+                            cost++;
+                        }
+                        else if (sa[i - 1 + ni] == special)
+                        { 
+                            // Discount matches on prefix
+                            tn--;
+                        }
+                    }
+                    float ec = (float)cost / tn;
+                    // Minimum of cell to the left+1, to the top+1, diagonally left and up +cost
+                    d[i] = Math.Min(Math.Min(d[i - 1] + 1, p[i] + 1), p[i - 1] + ec);
+                }
+                // Copy current distance counts to 'previous row' distance counts
+                d2 = p;
+                p = d;
+                d = d2;
+            }
+
+            // Our last action in the above loop was to switch d and p, so p now
+            // actually has the most recent cost counts
+            return p[sl] / Math.Max(tl, sl);
+        }
+    }
+}

--- a/F23.StringSimilarity/NormalizedLevenshtein.cs
+++ b/F23.StringSimilarity/NormalizedLevenshtein.cs
@@ -1,0 +1,82 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+using System;
+using F23.StringSimilarity.Interfaces;
+
+namespace F23.StringSimilarity
+{
+    /// This distance is computed as levenshtein distance divided by the length of
+    /// the longest string. The resulting value is always in the interval [0.0 1.0]
+    /// but it is not a metric anymore! The similarity is computed as 1 - normalized
+    /// distance.
+    public class NormalizedLevenshtein : INormalizedStringDistance, INormalizedStringSimilarity
+    {
+        private readonly Levenshtein l = new Levenshtein();
+
+        /// <summary>
+        /// Compute distance as Levenshtein(s1, s2) / max(|s1|, |s2|).
+        /// </summary>
+        /// <param name="s1">The first string to compare.</param>
+        /// <param name="s2">The second string to compare.</param>
+        /// <returns>The computed distance in the range [0, 1]</returns>
+        /// <exception cref="ArgumentNullException">If s1 or s2 is null.</exception>
+        public double Distance(string s1, string s2)
+        {
+            if (s1 == null)
+            {
+                throw new ArgumentNullException(nameof(s1));
+            }
+
+            if (s2 == null)
+            {
+                throw new ArgumentNullException(nameof(s2));
+            }
+
+            if (s1.Equals(s2))
+            {
+                return 0.0;
+            }
+
+            int m_len = Math.Max(s1.Length, s2.Length);
+
+            if (m_len == 0)
+            {
+                return 0.0;
+            }
+
+            return l.Distance(s1, s2) / m_len;
+        }
+
+        /// <summary>
+        /// Return 1 - distance.
+        /// </summary>
+        /// <param name="s1">The first string to compare.</param>
+        /// <param name="s2">The second string to compare.</param>
+        /// <returns>1 - distance</returns>
+        /// <exception cref="ArgumentNullException">If s1 or s2 is null.</exception>
+        public double Similarity(string s1, string s2)
+            => 1.0 - Distance(s1, s2);
+    }
+}

--- a/F23.StringSimilarity/OptimalStringAlignment.cs
+++ b/F23.StringSimilarity/OptimalStringAlignment.cs
@@ -1,0 +1,124 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+using System;
+using F23.StringSimilarity.Interfaces;
+// ReSharper disable SuggestVarOrType_Elsewhere
+// ReSharper disable TooWideLocalVariableScope
+
+namespace F23.StringSimilarity
+{
+    public sealed class OptimalStringAlignment : IStringDistance
+    {
+        /// <summary>
+        /// Compute the distance between strings: the minimum number of operations
+        /// needed to transform one string into the other (insertion, deletion,
+        /// substitution of a single character, or a transposition of two adjacent
+        /// characters) while no substring is edited more than once.
+        /// </summary>
+        /// <param name="s1">The first string to compare.</param>
+        /// <param name="s2">The second string to compare.</param>
+        /// <returns>the OSA distance</returns>
+        /// <exception cref="ArgumentNullException">If s1 or s2 is null.</exception>
+        public double Distance(string s1, string s2)
+        {
+            if (s1 == null)
+            {
+                throw new ArgumentNullException(nameof(s1));
+            }
+
+            if (s2 == null)
+            {
+                throw new ArgumentNullException(nameof(s2));
+            }
+
+            if (s1.Equals(s2))
+            {
+                return 0;
+            }
+
+            int n = s1.Length, m = s2.Length;
+
+            if (n == 0)
+            {
+                return m;
+            }
+
+            if (m == 0)
+            {
+                return n;
+            }
+
+            // Create the distance matrix H[0 .. s1.length+1][0 .. s2.length+1]
+            int[,] d = new int[n + 2, m + 2];
+
+            //initialize top row and leftmost column
+            for (int i = 0; i <= n; i++)
+            {
+                d[i, 0] = i;
+            }
+            for (int j = 0; j <= m; j++)
+            {
+                d[0, j] = j;
+            }
+
+            //fill the distance matrix
+            int cost;
+
+            for (int i = 1; i <= n; i++)
+            {
+                for (int j = 1; j <= m; j++)
+                {
+                    //if s1[i - 1] = s2[j - 1] then cost = 0, else cost = 1
+                    cost = 1;
+
+                    if (s1[i - 1] == s2[j - 1])
+                    {
+                        cost = 0;
+                    }
+
+                    d[i, j] = Min(
+                            d[i - 1, j - 1] + cost, // substitution
+                            d[i, j - 1] + 1,        // insertion
+                            d[i - 1, j] + 1         // deletion
+                    );
+
+                    //transposition check
+                    if (i > 1 && j > 1
+                            && s1[i - 1] == s2[j - 2]
+                            && s1[i - 2] == s2[j - 1]
+                        )
+                    {
+                        d[i, j] = Math.Min(d[i, j], d[i - 2, j - 2] + cost);
+                    }
+                }
+            }
+
+            return d[n, m];
+        }
+
+        private static int Min(int a, int b, int c)
+            => Math.Min(a, Math.Min(b, c));
+    }
+}

--- a/F23.StringSimilarity/Properties/AssemblyInfo.cs
+++ b/F23.StringSimilarity/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("F23.StringSimilarity.Tests")]

--- a/F23.StringSimilarity/QGram.cs
+++ b/F23.StringSimilarity/QGram.cs
@@ -1,0 +1,128 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+using System;
+using System.Collections.Generic;
+using F23.StringSimilarity.Interfaces;
+
+namespace F23.StringSimilarity
+{
+    /// Q-gram distance, as defined by Ukkonen in "Approximate string-matching with
+    /// q-grams and maximal matches". The distance between two strings is defined as
+    /// the L1 norm of the difference of their profiles (the number of occurences of
+    /// each n-gram): SUM( |V1_i - V2_i| ). Q-gram distance is a lower bound on
+    /// Levenshtein distance, but can be computed in O(m + n), where Levenshtein
+    /// requires O(m.n).
+    public class QGram : ShingleBased, IStringDistance
+    {
+        /// <summary>
+        /// Q-gram similarity and distance. Defined by Ukkonen in "Approximate
+        /// string-matching with q-grams and maximal matches",
+        /// http://www.sciencedirect.com/science/article/pii/0304397592901434 The
+        /// distance between two strings is defined as the L1 norm of the difference
+        /// of their profiles (the number of occurences of each k-shingle). Q-gram
+        /// distance is a lower bound on Levenshtein distance, but can be computed in
+        /// O(|A| + |B|), where Levenshtein requires O(|A|.|B|)
+        /// </summary>
+        /// <param name="k"></param>
+        public QGram(int k) : base(k) { }
+
+        /// <summary>
+        /// Q-gram similarity and distance. Defined by Ukkonen in "Approximate
+        /// string-matching with q-grams and maximal matches",
+        /// http://www.sciencedirect.com/science/article/pii/0304397592901434 The
+        /// distance between two strings is defined as the L1 norm of the difference
+        /// of their profiles (the number of occurence of each k-shingle). Q-gram
+        /// distance is a lower bound on Levenshtein distance, but can be computed in
+        /// O(|A| + |B|), where Levenshtein requires O(|A|.|B|)
+        /// Default k is 3.
+        /// </summary>
+        public QGram() { }
+
+        /// <summary>
+        /// The distance between two strings is defined as the L1 norm of the
+        /// difference of their profiles (the number of occurence of each k-shingle).
+        /// </summary>
+        /// <param name="s1">The first string to compare.</param>
+        /// <param name="s2">The second string to compare.</param>
+        /// <returns>The computed Q-gram distance.</returns>
+        /// <exception cref="ArgumentNullException">If s1 or s2 is null.</exception>
+        public double Distance(string s1, string s2)
+        {
+            if (s1 == null)
+            {
+                throw new ArgumentNullException(nameof(s1));
+            }
+
+            if (s2 == null)
+            {
+                throw new ArgumentNullException(nameof(s2));
+            }
+
+            if (s1.Equals(s2))
+            {
+                return 0;
+            }
+
+            var profile1 = GetProfile(s1);
+            var profile2 = GetProfile(s2);
+
+            return Distance(profile1, profile2);
+        }
+
+        /// <summary>
+        /// Compute QGram distance using precomputed profiles.
+        /// </summary>
+        /// <param name="profile1"></param>
+        /// <param name="profile2"></param>
+        /// <returns></returns>
+        public double Distance(IDictionary<string, int> profile1, IDictionary<string, int> profile2)
+        {
+            var union = new HashSet<string>();
+            union.UnionWith(profile1.Keys);
+            union.UnionWith(profile2.Keys);
+
+            int agg = 0;
+            foreach (var key in union)
+            {
+                int v1 = 0;
+                int v2 = 0;
+
+                if (profile1.TryGetValue(key, out var iv1))
+                {
+                    v1 = iv1;
+                }
+
+                if (profile2.TryGetValue(key, out var iv2))
+                {
+                    v2 = iv2;
+                }
+
+                agg += Math.Abs(v1 - v2);
+            }
+
+            return agg;
+        }
+    }
+}

--- a/F23.StringSimilarity/ShingleBased.cs
+++ b/F23.StringSimilarity/ShingleBased.cs
@@ -1,0 +1,85 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text.RegularExpressions;
+
+namespace F23.StringSimilarity
+{
+    public abstract class ShingleBased
+    {
+        private const int DEFAULT_K = 3;
+
+        /// <summary>
+        /// Return k, the length of k-shingles (aka n-grams).
+        /// </summary>
+        protected int k { get; }
+
+        /// <summary>
+        /// Pattern for finding multiple following spaces
+        /// </summary>
+        private static readonly Regex SPACE_REG = new Regex("\\s+");
+
+        /// <summary> 
+        /// </summary>
+        /// <param name="k"></param>
+        /// <exception cref="ArgumentOutOfRangeException">If k is less than or equal to 0.</exception>
+        protected ShingleBased(int k)
+        {
+            if (k <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(k), "k should be positive!");
+            }
+
+            this.k = k;
+        }
+        
+        protected ShingleBased() : this(DEFAULT_K) { }
+
+        protected IDictionary<string, int> GetProfile(string s)
+        {
+            var shingles = new Dictionary<string, int>();
+
+            var string_no_space = SPACE_REG.Replace(s, " ");
+
+            for (int i = 0; i < (string_no_space.Length - k + 1); i++)
+            {
+                var shingle = string_no_space.Substring(i, k);
+
+                if (shingles.TryGetValue(shingle, out var old))
+                {
+                    shingles[shingle] = old + 1;
+                }
+                else
+                {
+                    shingles[shingle] = 1;
+                }
+            }
+
+            return new ReadOnlyDictionary<string, int>(shingles);
+        }
+    }
+}

--- a/F23.StringSimilarity/SorensenDice.cs
+++ b/F23.StringSimilarity/SorensenDice.cs
@@ -1,0 +1,113 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+using System;
+using System.Collections.Generic;
+using F23.StringSimilarity.Interfaces;
+
+// ReSharper disable LoopCanBeConvertedToQuery
+
+namespace F23.StringSimilarity
+{
+    /// Similar to Jaccard index, but this time the similarity is computed as 2 * |V1
+    /// inter V2| / (|V1| + |V2|). Distance is computed as 1 - cosine similarity.
+    public class SorensenDice : ShingleBased, INormalizedStringDistance, INormalizedStringSimilarity
+    {
+        /// <summary>
+        /// Sorensen-Dice coefficient, aka Sørensen index, Dice's coefficient or
+        /// Czekanowski's binary (non-quantitative) index.
+        ///
+        /// The strings are first converted to boolean sets of k-shingles (sequences
+        /// of k characters), then the similarity is computed as 2 * |A inter B| /
+        /// (|A| + |B|). Attention: Sorensen-Dice distance (and similarity) does not
+        /// satisfy triangle inequality.
+        /// </summary>
+        /// <param name="k"></param>
+        public SorensenDice(int k) : base(k) { }
+
+        /// <summary>
+        /// Sorensen-Dice coefficient, aka Sørensen index, Dice's coefficient or
+        /// Czekanowski's binary (non-quantitative) index.
+        ///
+        /// The strings are first converted to boolean sets of k-shingles (sequences
+        /// of k characters), then the similarity is computed as 2 * |A inter B| /
+        /// (|A| + |B|). Attention: Sorensen-Dice distance (and similarity) does not
+        /// satisfy triangle inequality.
+        /// Default k is 3.
+        /// </summary>
+        public SorensenDice() { }
+
+        /// <summary>
+        /// Similarity is computed as 2 * |A inter B| / (|A| + |B|).
+        /// </summary>
+        /// <param name="s1">The first string to compare.</param>
+        /// <param name="s2">The second string to compare.</param>
+        /// <returns>The computed Sorensen-Dice similarity.</returns>
+        /// <exception cref="ArgumentNullException">If s1 or s2 is null.</exception>
+        public double Similarity(string s1, string s2)
+        {
+            if (s1 == null)
+            {
+                throw new ArgumentNullException(nameof(s1));
+            }
+
+            if (s2 == null)
+            {
+                throw new ArgumentNullException(nameof(s2));
+            }
+
+            if (s1.Equals(s2))
+            {
+                return 1;
+            }
+
+            var profile1 = GetProfile(s1);
+            var profile2 = GetProfile(s2);
+
+            var union = new HashSet<string>();
+            union.UnionWith(profile1.Keys);
+            union.UnionWith(profile2.Keys);
+            
+            int inter = 0;
+
+            foreach (var key in union)
+            {
+                if (profile1.ContainsKey(key) && profile2.ContainsKey(key))
+                    inter++;
+            }
+
+            return 2.0 * inter / (profile1.Count + profile2.Count);
+        }
+
+        /// <summary>
+        /// Returns 1 - similarity.
+        /// </summary>
+        /// <param name="s1">The first string to compare.</param>
+        /// <param name="s2">The second string to compare.</param>
+        /// <returns>1.0 - the computed similarity</returns>
+        /// <exception cref="ArgumentNullException">If s1 or s2 is null.</exception>
+        public double Distance(string s1, string s2)
+            => 1 - Similarity(s1, s2);
+    }
+}

--- a/F23.StringSimilarity/Support/ArrayExtensions.cs
+++ b/F23.StringSimilarity/Support/ArrayExtensions.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+using System;
+using System.Linq;
+
+namespace F23.StringSimilarity.Support
+{
+    internal static class ArrayExtensions
+    {
+        internal static T[] WithPadding<T>(this T[] source, int finalLength, T paddingValue = default(T))
+        {
+            if (finalLength < source.Length)
+                throw new InvalidOperationException("Final length must be greater than or equal to current length.");
+
+            if (finalLength == source.Length)
+                return source;
+
+            var result = new T[finalLength];
+            var padding = Enumerable.Repeat(paddingValue, finalLength - source.Length).ToArray();
+
+            Array.Copy(source, sourceIndex: 0, destinationArray: result, destinationIndex: 0, length: source.Length);
+            Array.Copy(padding, sourceIndex: 0, destinationArray: result, destinationIndex: source.Length, length: padding.Length);
+
+            return result;
+        }
+    }
+}

--- a/F23.StringSimilarity/WeightedLevenshtein.cs
+++ b/F23.StringSimilarity/WeightedLevenshtein.cs
@@ -1,0 +1,133 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+using System;
+using F23.StringSimilarity.Interfaces;
+// ReSharper disable SuggestVarOrType_Elsewhere
+// ReSharper disable TooWideLocalVariableScope
+
+namespace F23.StringSimilarity
+{
+    /// Implementation of Levenshtein that allows to define different weights for
+    /// different character substitutions.
+    public class WeightedLevenshtein : IStringDistance
+    {
+        private readonly ICharacterSubstitution _characterSubstitution;
+
+        /// <summary>
+        /// Create a new instance with provided character substitution.
+        /// </summary>
+        /// <param name="characterSubstitution">The strategy to determine character substitution weights.</param>
+        public WeightedLevenshtein(ICharacterSubstitution characterSubstitution)
+        {
+            _characterSubstitution = characterSubstitution;
+        }
+
+        /// <summary>
+        /// Compute Levenshtein distance using provided weights for substitution.
+        /// </summary>
+        /// <param name="s1">The first string to compare.</param>
+        /// <param name="s2">The second string to compare.</param>
+        /// <returns>The computed weighted Levenshtein distance.</returns>
+        /// <exception cref="ArgumentNullException">If s1 or s2 is null.</exception>
+        public double Distance(string s1, string s2)
+        {
+            if (s1 == null)
+            {
+                throw new ArgumentNullException(nameof(s1));
+            }
+
+            if (s2 == null)
+            {
+                throw new ArgumentNullException(nameof(s2));
+            }
+
+            if (s1.Equals(s2))
+            {
+                return 0;
+            }
+
+            if (s1.Length == 0)
+            {
+                return s2.Length;
+            }
+
+            if (s2.Length == 0)
+            {
+                return s1.Length;
+            }
+
+            // create two work vectors of integer distances
+            double[] v0 = new double[s2.Length + 1];
+            double[] v1 = new double[s2.Length + 1];
+            double[] vtemp;
+
+            // initialize v0 (the previous row of distances)
+            // this row is A[0][i]: edit distance for an empty s
+            // the distance is just the number of characters to delete from t
+            for (int i = 0; i < v0.Length; i++)
+            {
+                v0[i] = i;
+            }
+
+            for (int i = 0; i < s1.Length; i++)
+            {
+                // calculate v1 (current row distances) from the previous row v0
+                // first element of v1 is A[i+1][0]
+                //   edit distance is delete (i+1) chars from s to match empty t
+                v1[0] = i + 1;
+
+                // use formula to fill in the rest of the row
+                for (int j = 0; j < s2.Length; j++)
+                {
+                    double cost = 0;
+                    double insertioncost = 0;
+                    double deletioncost = 0;
+                    if (s1[i] != s2[j])
+                    {
+                        cost = _characterSubstitution.Cost(s1[i], s2[j]);
+                        insertioncost=_characterSubstitution.InsertionCost(s2[j]);
+                        deletioncost=_characterSubstitution.DeletionCost(s1[i]);
+                    }
+
+                    v1[j + 1] = Math.Min(
+                            v1[j] + insertioncost, // Cost of insertion
+                            Math.Min(
+                                    v0[j + 1] + deletioncost, // Cost of remove
+                                    v0[j] + cost)); // Cost of substitution
+                }
+
+                // copy v1 (current row) to v0 (previous row) for next iteration
+                //System.arraycopy(v1, 0, v0, 0, v0.length);
+                // Flip references to current and previous row
+                vtemp = v0;
+                v0 = v1;
+                v1 = vtemp;
+
+            }
+
+            return v0[s2.Length];
+        }
+    }
+}

--- a/LICENSE.StringSimilarity
+++ b/LICENSE.StringSimilarity
@@ -1,0 +1,44 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 feature[23]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Portions of this code are licensed and copyright as follows:
+
+Copyright 2015 Thibault Debatty.
+ 
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/NeteaseLyrics.csproj
+++ b/NeteaseLyrics.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\Costura.Fody.3.2.2\build\Costura.Fody.props" Condition="Exists('packages\Costura.Fody.3.2.2\build\Costura.Fody.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -78,12 +77,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Costura, Version=3.2.2.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
-      <HintPath>packages\Costura.Fody.3.2.2\lib\net40\Costura.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.12.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
@@ -92,6 +85,29 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DataStucture.cs" />
+    <Compile Include="F23.StringSimilarity\Cosine.cs" />
+    <Compile Include="F23.StringSimilarity\Damerau.cs" />
+    <Compile Include="F23.StringSimilarity\Experimental\Sift4.cs" />
+    <Compile Include="F23.StringSimilarity\ICharacterSubstitution.cs" />
+    <Compile Include="F23.StringSimilarity\Interfaces\IMetricStringDistance.cs" />
+    <Compile Include="F23.StringSimilarity\Interfaces\INormalizedStringDistance.cs" />
+    <Compile Include="F23.StringSimilarity\Interfaces\INormalizedStringSimilarity.cs" />
+    <Compile Include="F23.StringSimilarity\Interfaces\IStringDistance.cs" />
+    <Compile Include="F23.StringSimilarity\Interfaces\IStringSimilarity.cs" />
+    <Compile Include="F23.StringSimilarity\Jaccard.cs" />
+    <Compile Include="F23.StringSimilarity\JaroWinkler.cs" />
+    <Compile Include="F23.StringSimilarity\Levenshtein.cs" />
+    <Compile Include="F23.StringSimilarity\LongestCommonSubsequence.cs" />
+    <Compile Include="F23.StringSimilarity\MetricLCS.cs" />
+    <Compile Include="F23.StringSimilarity\NGram.cs" />
+    <Compile Include="F23.StringSimilarity\NormalizedLevenshtein.cs" />
+    <Compile Include="F23.StringSimilarity\OptimalStringAlignment.cs" />
+    <Compile Include="F23.StringSimilarity\Properties\AssemblyInfo.cs" />
+    <Compile Include="F23.StringSimilarity\QGram.cs" />
+    <Compile Include="F23.StringSimilarity\ShingleBased.cs" />
+    <Compile Include="F23.StringSimilarity\SorensenDice.cs" />
+    <Compile Include="F23.StringSimilarity\Support\ArrayExtensions.cs" />
+    <Compile Include="F23.StringSimilarity\WeightedLevenshtein.cs" />
     <Compile Include="LyricProcessor.cs" />
     <Compile Include="MusicBeeInterface.cs" />
     <Compile Include="NeteaseLyrics.cs" />
@@ -99,7 +115,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.0">
@@ -123,17 +138,20 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Costura.Fody">
+      <Version>3.2.2</Version>
+    </PackageReference>
+    <PackageReference Include="MSBuildTasks">
+      <Version>1.5.0.235</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>13.0.1</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="packages\Fody.3.3.5\build\Fody.targets" Condition="Exists('packages\Fody.3.3.5\build\Fody.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>这台计算机上缺少此项目引用的 NuGet 程序包。使用“NuGet 程序包还原”可下载这些程序包。有关更多信息，请参见 http://go.microsoft.com/fwlink/?LinkID=322105。缺少的文件是 {0}。</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('packages\Fody.3.3.5\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Fody.3.3.5\build\Fody.targets'))" />
-    <Error Condition="!Exists('packages\Costura.Fody.3.2.2\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Costura.Fody.3.2.2\build\Costura.Fody.props'))" />
-    <Error Condition="!Exists('packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets'))" />
-  </Target>
-  <Import Project="packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets" Condition="Exists('packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" />
   <Target Name="AfterBuild" Condition="'$(Configuration)'=='Release'">
     <ItemGroup>
       <ZipFiles Include="pkgtemp\" />

--- a/NeteaseLyrics.sln
+++ b/NeteaseLyrics.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NeteaseLyrics", "NeteaseLyrics.csproj", "{F5D46BA1-6F21-40EF-9695-46105CCACD08}"
 EndProject
@@ -24,5 +24,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {34A35759-145D-40FF-B4F6-0D7ED294BEA9}
 	EndGlobalSection
 EndGlobal

--- a/packages.config
+++ b/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Costura.Fody" version="3.2.2" targetFramework="net40" />
-  <package id="Fody" version="3.3.5" targetFramework="net40" developmentDependency="true" />
-  <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net40" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net40" />
-</packages>


### PR DESCRIPTION
使用 [StringSimilarity.NET](https://github.com/glienard/StringSimilarity.NET) 中实现的 Jaro-Winkler 算法来提升歌曲匹配准确度。

采用对歌名占65%，专辑名占25%，艺术家占10%的加权平均处理网易云获取到的歌曲与本地歌曲的相似度。

同时，由于<https://getmusicbee.com/forum/index.php?topic=16285.0> 中所说：
```
MB strips the brackets and text within the bracket from the track title before calling the lyrics api. There is no way to control that, although i could add support for the plugin to indicate it will handle that. I would only do that if i knew a lyrics plugin developer would make use of the change
```
所以在`RetrieveLyrics`中加了一行`var realTitle = _mbApiInterface.NowPlaying_GetFileTag(MetaDataType.TrackTitle);`来获取真实曲目标题。

## 效果
![9fc1663abfba7759e44ef8ef793fa966](https://github.com/cqjjjzr/MusicBee-NeteaseLyrics/assets/6669365/62dc03dd-6529-4a30-910f-3de7a31d4e0a)
![39fe5fa7a6c7d576111172512e47c7c0](https://github.com/cqjjjzr/MusicBee-NeteaseLyrics/assets/6669365/ac3e93ca-7380-4f15-b9f7-973d71c79e9e)

![image](https://github.com/cqjjjzr/MusicBee-NeteaseLyrics/assets/6669365/b7edbc85-1b2c-4340-b3ba-b0236d664680)
![image](https://github.com/cqjjjzr/MusicBee-NeteaseLyrics/assets/6669365/ea79ec5e-b897-41f2-8ea5-b790206accbf)
