### PR TITLE
feat: match netease album id

### DIFF
--- a/DataStucture.cs
+++ b/DataStucture.cs
@@ -5,6 +5,17 @@
 
 namespace MusicBeePlugin
 {
+    internal class AlbumResult
+    {
+        public int code;
+        public IEnumerable<AlbumResultSong> songs;
+    }
+
+    internal class AlbumResultSong
+    {
+        public long id;
+    }
+
     internal class SearchResult
     {
         public SearchResultResult result;

--- a/NeteaseApi.cs
+++ b/NeteaseApi.cs
@@ -14,6 +14,21 @@ namespace MusicBeePlugin
      */
     internal static class NeteaseApi
     {
+        public static IEnumerable<AlbumResultSong> GetAlbum(long id)
+        {
+            var postData = new Dictionary<string, object>
+            {
+                { "csrf_token", "" },
+                { "crypto", "weapi" },
+                { "offset", 0 },
+                { "type", 1 },
+                { "limit", 20 }
+            };
+            var result = RequestNewApi<AlbumResult>($@"https://music.163.com/weapi/v1/album/{id}",
+                postData, it => it.code == 200);
+            return result == null ? Enumerable.Empty<AlbumResultSong>() : result.songs;
+        }
+
         public static IEnumerable<SearchResultSong> Search(string s)
         {
             var postData = new Dictionary<string, object>
@@ -36,19 +51,20 @@ namespace MusicBeePlugin
         {
             var postData = new Dictionary<string, object>
                     {
-                        { "OS", "pc" },
+                        { "os", "ios" },
                         { "id", id },
+                        { "cp", false },
                         { "lv", -1 },
                         { "kv", -1 },
                         { "tv", -1 },
-                        { "rv", -1 }
+                        { "rv", -1 },
                     };
             return RequestNewApi<LyricResult>(
-                @"https://music.163.com/weapi/song/lyric?csrf_token=", 
+                @"https://music.163.com/api/song/lyric?_nmclfl=1", 
                 postData, it => it.code == 200) ?? RequestLyricLegacy(id);
         }
 
-        private static T RequestNewApi<T>(string url, Dictionary<string, object> postData, Func<T, bool> checkFunc) 
+        public static T RequestNewApi<T>(string url, Dictionary<string, object> postData, Func<T, bool> checkFunc) 
             where T : class
         {
             try

--- a/NeteaseLyrics.cs
+++ b/NeteaseLyrics.cs
@@ -28,6 +28,18 @@ namespace MusicBeePlugin
         public bool UseLegacyMatch { get; set; }
     }
 
+    public enum CustomTagType
+    {
+        Album, Song
+    }
+
+    public class CustomTagParseResult
+    {
+        public long Id { get; set; }
+
+        public CustomTagType Type { get; set; }
+    }
+
     public partial class Plugin
     {
         private const string ProviderName = "Netease Cloud Music(网易云音乐)";
@@ -168,7 +180,31 @@ namespace MusicBeePlugin
             var specifiedId = _mbApiInterface.Library_GetFileTag(sourceFileUrl, MetaDataType.Custom10)
                               ?? _mbApiInterface.NowPlaying_GetFileTag(MetaDataType.Custom10);
 
-            var id = TryParseNeteaseUrl(specifiedId);
+            long id = 0;
+            var result = TryParseNeteaseUrl(specifiedId);
+            if (result != null)
+            {
+                if (result.Type == CustomTagType.Song) id = result.Id;
+                else if (result.Type == CustomTagType.Album && result.Id != 0)
+                {
+                    var songList = NeteaseApi.GetAlbum(result.Id).ToList();
+                    //long.TryParse(_mbApiInterface.Library_GetFileTag(sourceFileUrl, MetaDataType.DiscNo) ??
+                    //             _mbApiInterface.NowPlaying_GetFileTag(MetaDataType.DiscNo), out var discNo);
+                    
+                    int.TryParse(_mbApiInterface.Library_GetFileTag(sourceFileUrl, MetaDataType.TrackNo) ??
+                                             _mbApiInterface.NowPlaying_GetFileTag(MetaDataType.TrackNo), out var trackNo);
+
+                    //if (discNo <= 0) discNo = 1;
+                    if (trackNo <= 0) trackNo = 1;
+
+                    
+
+                    if (songList.Count >= trackNo)
+                    {
+                        id = songList[trackNo - 1]?.id ?? 0;
+                    }
+                }
+            }
             if (id == 0)
             {
                 var realTitle = _mbApiInterface.Library_GetFileTag(sourceFileUrl, MetaDataType.TrackTitle);
@@ -220,31 +256,53 @@ namespace MusicBeePlugin
             SaveSettingsInternal();
         }
 
-        private static long TryParseNeteaseUrl(string input)
+        private static CustomTagParseResult TryParseNeteaseUrl(string input)
         {
             if (input == null)
-                return 0;
+                return null;
+            if (input.StartsWith("album="))
+            {
+                input = input.Substring("album=".Length);
+                long.TryParse(input, out var id);
+                return new CustomTagParseResult { Id = id, Type = CustomTagType.Album };
+            }
             if (input.StartsWith("netease="))
             {
                 input = input.Substring("netease=".Length);
                 long.TryParse(input, out var id);
-                return id;
+                return new CustomTagParseResult { Id = id, Type = CustomTagType.Song };
             }
 
             if (!input.Contains("music.163.com"))
-                return 0;
+                return null;
 
-            var matches = Regex.Matches(input, "id=(\\d+)");
-            if (matches.Count <= 0)
-                return 0;
+            var matches = Regex.Matches(input, @"song\?id=(\d+)");
+            if (matches.Count > 0)
+            {
+                var groups = matches[0].Groups;
+                if (groups.Count <= 1)
+                    return null;
 
-            var groups = matches[0].Groups;
-            if (groups.Count <= 1)
-                return 0;
+                var idString = groups[1].Captures[0].Value;
+                long.TryParse(idString, out var id2);
+                return new CustomTagParseResult { Id = id2, Type = CustomTagType.Song };
+            }
+            else
+            {
+                matches = Regex.Matches(input, @"album\?id=(\d+)");
+                if (matches.Count > 0)
+                {
+                    var groups = matches[0].Groups;
+                    if (groups.Count <= 1)
+                        return null;
 
-            var idString = groups[1].Captures[0].Value;
-            long.TryParse(idString, out var id2);
-            return id2;
+                    var idString = groups[1].Captures[0].Value;
+                    long.TryParse(idString, out var id2);
+                    return new CustomTagParseResult { Id = id2, Type = CustomTagType.Album };
+                }
+            }
+
+            return null;
         }
 
         private static long ParseDurationString(string durationStr)


### PR DESCRIPTION
增加在 custom10 字段中匹配 album= 和 album?id= 专辑 ID 的功能，现在可以批量编辑整个专辑的 custom10 字段并于网易云上的专辑 ID 匹配。

未完成：一个专辑存在多个 Disc 的时候，Track No 就不等于网易云上的 ID 了，需要进一步挖掘 API